### PR TITLE
added functionality to support multiple session via serial number

### DIFF
--- a/src/rtt_console/console.py
+++ b/src/rtt_console/console.py
@@ -100,6 +100,7 @@ def main():
 
     parser.add_argument(f'-s', '--speed', type=int, help='Target speed (default: auto)', required=False, default=0)
     parser.add_argument('-p', '--path', type=str, help='Path to JLink DLL', required=False, default="")
+    parser.add_argument('-i', '--id', type=str, help='ID (serial) of connected device', required=False, default=None)
     parser.add_argument('-pwr',
                         '--power',
                         help='Power on target by JLink',
@@ -108,7 +109,7 @@ def main():
 
     args = parser.parse_args()
     args.speed = 'auto' if args.speed == 0 else args.speed
-    jlink = JLinkDongle(chip_name=args.target, speed=args.speed, dll_path=args.path, pwr_target=args.power)
+    jlink = JLinkDongle(chip_name=args.target, speed=args.speed, dll_path=args.path, pwr_target=args.power, serial=args.id)
     jlink_broken = connect(jlink)
 
     if not jlink_broken:

--- a/src/rtt_console/jlink_dongle.py
+++ b/src/rtt_console/jlink_dongle.py
@@ -24,6 +24,7 @@ class JLinkDongle:
     jlink:JLink = field(init=False)
     dll_path:str = ""
     pwr_target:bool = False
+    serial:str = None
 
     def check_exception(func): # type: ignore
         @functools.wraps(func)  # type: ignore
@@ -54,7 +55,7 @@ class JLinkDongle:
             print(f"ERROR: JLink libs not found: {e}")
             return False
         self.jlink.disable_dialog_boxes()
-        self.jlink.open()
+        self.jlink.open(serial_no=self.serial)
         self.jlink.power_on() if self.pwr_target else self.jlink.power_off()
         self.jlink.rtt_stop()
         self.jlink.set_tif(JLinkInterfaces.SWD)


### PR DESCRIPTION
This enables the connection of two JLink debuggers simultaneously. They are differentiated by the serial number of the debugger.
Another command line argument was added.
```bash
usage: console [-h] [-t TARGET] [-s SPEED] [-p PATH] [-i ID] [-pwr POWER]

RTT Console v0.2.7

optional arguments:
  -h, --help            show this help message and exit
  -t TARGET, --target TARGET
                        Target chip name (example: STM32F407VE)
  -s SPEED, --speed SPEED
                        Target speed (default: auto)
  -p PATH, --path PATH  Path to JLink DLL
  -i ID, --id ID        ID (serial) of connected device
  -pwr POWER, --power POWER
                        Power on target by JLink

```
Multiple sessions can now be started without selecting the debugger via a GUI.
`rtt-console -i 111111111`
`rtt-console -i 222222222`